### PR TITLE
Update default value for connectivity in CD workflow to false

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -41,7 +41,7 @@ on:
       connectivity:
         description: 'Run Steps: Connectivity'
         type: boolean
-        default: true
+        default: false
       destroy:
         description: '[DANGER!] Destroy? [DANGER!]'
         default: false


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/cd.yaml` file. The change modifies the default value of the `connectivity` parameter from `true` to `false`.