### PR TITLE
Set value for parPrivateDnsResourceGroupId

### DIFF
--- a/config/custom-parameters/alzDefaultPolicyAssignments.parameters.all.json
+++ b/config/custom-parameters/alzDefaultPolicyAssignments.parameters.all.json
@@ -51,7 +51,7 @@
       "value": ""
     },
     "parPrivateDnsResourceGroupId": {
-      "value": ""
+      "value": "/subscriptions/210af666-7a18-42e4-b385-7a8231807ece/resourceGroups/rg-cnsa-private-dns"
     },
     "parPrivateDnsZonesNamesToAuditInCorp": {
       "value": []


### PR DESCRIPTION
This pull request includes a change to the `config/custom-parameters/alzDefaultPolicyAssignments.parameters.all.json` file. The change updates the value of the `parPrivateDnsResourceGroupId` parameter to reference a specific resource group.

* [`config/custom-parameters/alzDefaultPolicyAssignments.parameters.all.json`](diffhunk://#diff-277377af0c8c909cd9db4e1c9774795c22c3bd1634c17090c58787641b32ac38L54-R54): Updated the `parPrivateDnsResourceGroupId` parameter to reference `/subscriptions/210af666-7a18-42e4-b385-7a8231807ece/resourceGroups/rg-cnsa-private-dns`.